### PR TITLE
Make the dummy test pass

### DIFF
--- a/tests/integration/specs/spec.dummy.js
+++ b/tests/integration/specs/spec.dummy.js
@@ -15,6 +15,8 @@ describe('Django CMS website', function () {
     it('should have a title', function () {
         browser.get(dummyPage.site);
 
-        expect(browser.getTitle()).toContain('django-cms');
+        expect(
+            browser.getTitle().toLowerCase().replace('-', ' '))
+            .toContain('django cms');
     });
 });


### PR DESCRIPTION
In some cases the title is 'django CMS - ...' and in other cases it is 'django-cms'. Make the test accept either.

This should fix https://travis-ci.org/divio/django-cms-demo/jobs/124509897