### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Manual
 #. Once you have created a project, copy all files from inside the
    django-cms-explorer project into your projects ``mysite/`` directory.
    More about the file structure is documented in our 
-   `boilerplate guidelines <https://aldryn-boilerplate-bootstrap3.readthedocs.org/en/latest/structure/index.html>`_.
+   `boilerplate guidelines <https://aldryn-boilerplate-bootstrap3.readthedocs.io/en/latest/structure/index.html>`_.
 #. Restart your server and open your site using ``http://localhost:8000/en/``.
 
 You are ready to create your own theme.

--- a/templates/includes/menu/navigation.html
+++ b/templates/includes/menu/navigation.html
@@ -1,5 +1,5 @@
 {% load i18n menu_tags cache %}
-{# DOCS: http://django-cms.readthedocs.org/en/latest/advanced/templatetags.html#show-menu-examples #}
+{# DOCS: http://docs.django-cms.org/en/latest/reference/navigation.html#show-menu #}
 
 {% for child in children %}
 <li class="child{% if child.ancestor %} ancestor{% endif %}{% if child.selected %} active{% endif %}{% if child.children and dropdown %} children dropdown{% endif %}{% if forloop.first %} first{% endif %}{% if forloop.last %} last{% endif %}">

--- a/tools/server/src/settings.py
+++ b/tools/server/src/settings.py
@@ -34,7 +34,7 @@ ALLOWED_HOSTS = ['*']
 
 INSTALLED_APPS = (
     # djangocms_admin_style needs to be before django.contrib.admin!
-    # https://django-cms.readthedocs.org/en/develop/how_to/install.html#configuring-your-project-for-django-cms
+    # http://docs.django-cms.org/en/latest/how_to/install.html#configuring-your-project-for-django-cms
     'djangocms_admin_style',
     # django defaults
     'django.contrib.admin',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.